### PR TITLE
Fix/#27 jwtpayload 수정

### DIFF
--- a/src/auth/jwt/jwt.payload.ts
+++ b/src/auth/jwt/jwt.payload.ts
@@ -1,7 +1,7 @@
 export class Payload {
   email!: string; // user email
   period!: string;
-  sub!: number; // userId
+  sub!: string; // userId
 }
 
 export const ONEDAY = '1d';


### PR DESCRIPTION
## Description
`export class Payload {
  email!: string; // user email
  period!: string;
  sub!: number; // userId
}`
위와 같이 되어 있어 오류 발생, sub의 타입을 string으로 수정

## Changes
- [x] jwt.payload의 sub 타입 변경

## Additional context

Closes #27 