### PR TITLE
Feature/#59 진도율 로직 수정 및 api 수정

### DIFF
--- a/src/learnings/dtos/chapters.dto.ts
+++ b/src/learnings/dtos/chapters.dto.ts
@@ -3,4 +3,5 @@ import { CoreRes } from 'src/common/dtos/Response.dto';
 
 export class GetChaptersRes extends CoreRes {
   chapters!: Chapter[];
+  progress!: number;
 }

--- a/src/learnings/learnings.service.ts
+++ b/src/learnings/learnings.service.ts
@@ -30,6 +30,11 @@ export class LearningsService {
           completedChapters: {
             learning: true,
           },
+          completedProblems: {
+            chapter: {
+              learning: true,
+            },
+          },
         },
       });
       if (!userInDb) {
@@ -52,16 +57,21 @@ export class LearningsService {
         throw new NotFoundException('Chapters not found within the learning');
       const totalChaptersCount = learning.chapters.length;
 
-      // 해당 타입 내 완료한 챕터 수
-      const completedChaptersCount = userInDb.completedChapters.filter(
-        (chapter) => chapter.learning.type === +type,
-      ).length;
+      // 푼 문제 중 현재 타입과 일치하는 것 필터링
+      const completedProblems = userInDb.completedProblems.filter(
+        (problem) => problem.chapter.learning.type === +type,
+      );
 
-      const percentage = (completedChaptersCount / totalChaptersCount) * 100;
+      const completedProblemsCount = completedProblems.length;
+
+      // 전체 챕터 수 * 3(각 챕터별 문제 수) = 100%
+      const progress = Math.floor(
+        (completedProblemsCount / (totalChaptersCount * 3)) * 100,
+      );
       return {
         statusCode: 200,
         message: 'Progress successfully retrieved',
-        progress: percentage,
+        progress,
       };
     } catch (e) {
       throw e;

--- a/src/learnings/learnings.service.ts
+++ b/src/learnings/learnings.service.ts
@@ -100,10 +100,14 @@ export class LearningsService {
         chapter['isCompleted'] = isCompleted;
       });
 
+      // 진도율 추가
+      const { progress } = await this.getProgress(user, type);
+
       return {
         statusCode: 200,
         message: 'Chapters successfully retrieved',
         chapters: learning.chapters,
+        progress,
       };
     } catch (e) {
       throw e;


### PR DESCRIPTION
## Description
진도율 로직 수정 및 목차 조회 api의 response body에도 진도율 반환하도록 수정

## Changes
- learnings service
    - getProgress method 진도율 계산 로직
    - getChapters method의 response


[목차 조회 api 명세서](https://www.notion.so/likelion-11th/chapters-type-type-19e8005373bb45bc9a3a31e42920f793?pvs=4)  
위 api의 response body에 progress property 추가  

`Before`
```json
{
    "statusCode": 200,
    "message": "Chapters successfully retrieved",
    "chapters": [
        {
            "id": "4d34615a-50be-4dac-9a76-1558d749bde8",
            "title": "챕터 1",
            "help_message": null,
            "isCompleted": true
        },
        {
            "id": "b18b3b5b-4dbc-4a9a-89d6-4e61aa4ceb2c",
            "title": "챕터 2",
            "help_message": null,
            "isCompleted": false
        }
    ]
}
```

`After`
```json
{
    "statusCode": 200,
    "message": "Chapters successfully retrieved",
    "chapters": [
        {
            "id": "4d34615a-50be-4dac-9a76-1558d749bde8",
            "title": "챕터 1",
            "helpMessage": "blah",
            "isCompleted": true
        },
        {
            "id": "b18b3b5b-4dbc-4a9a-89d6-4e61aa4ceb2c",
            "title": "챕터 2",
            "helpMessage": null,
            "isCompleted": false
        }
    ],
    "progress": 16
}
```

## Additional context
- 각 챕터별 완료 조건이 해당 챕터의 문제를 3개 이상 푸는 것이므로  
    해당 학습(기초 또는 심화) 내의 푼 문제 수를 전체 챕터 수 * 3으로 나눠서 구하도록 수정함.
- 목차 조회 api의 response body에 진도율 추가


Closes #59 