### PR TITLE
Feature/#72 chapter에 순서 부여

### DIFF
--- a/src/chapters/entities/chapter.entity.ts
+++ b/src/chapters/entities/chapter.entity.ts
@@ -5,7 +5,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { IsString } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 import { Problem } from 'src/problems/entities/problem.entity';
 import { Learning } from 'src/learnings/entities/learning.entity';
 
@@ -21,6 +21,10 @@ export class Chapter {
   @Column({ nullable: true })
   @IsString()
   helpMessage?: string;
+
+  @Column()
+  @IsNumber()
+  order!: number;
 
   @OneToMany((type) => Problem, (problem) => problem.chapter, {
     nullable: true,

--- a/src/learnings/dtos/chapters.dto.ts
+++ b/src/learnings/dtos/chapters.dto.ts
@@ -3,4 +3,5 @@ import { CoreRes } from 'src/common/dtos/Response.dto';
 
 export class GetChaptersRes extends CoreRes {
   chapters!: Chapter[];
+  progress!: number;
 }

--- a/src/learnings/learnings.service.ts
+++ b/src/learnings/learnings.service.ts
@@ -30,6 +30,11 @@ export class LearningsService {
           completedChapters: {
             learning: true,
           },
+          completedProblems: {
+            chapter: {
+              learning: true,
+            },
+          },
         },
       });
       if (!userInDb) {
@@ -52,16 +57,21 @@ export class LearningsService {
         throw new NotFoundException('Chapters not found within the learning');
       const totalChaptersCount = learning.chapters.length;
 
-      // 해당 타입 내 완료한 챕터 수
-      const completedChaptersCount = userInDb.completedChapters.filter(
-        (chapter) => chapter.learning.type === +type,
-      ).length;
+      // 푼 문제 중 현재 타입과 일치하는 것 필터링
+      const completedProblems = userInDb.completedProblems.filter(
+        (problem) => problem.chapter.learning.type === +type,
+      );
 
-      const percentage = (completedChaptersCount / totalChaptersCount) * 100;
+      const completedProblemsCount = completedProblems.length;
+
+      // 전체 챕터 수 * 3(각 챕터별 문제 수) = 100%
+      const progress = Math.floor(
+        (completedProblemsCount / (totalChaptersCount * 3)) * 100,
+      );
       return {
         statusCode: 200,
         message: 'Progress successfully retrieved',
-        progress: percentage,
+        progress,
       };
     } catch (e) {
       throw e;

--- a/src/learnings/learnings.service.ts
+++ b/src/learnings/learnings.service.ts
@@ -97,6 +97,11 @@ export class LearningsService {
         relations: {
           chapters: true,
         },
+        order: {
+          chapters: {
+            order: 'ASC',
+          },
+        },
       });
       if (!learning) throw new NotFoundException('Learning not found ');
       if (learning.chapters.length === 0)

--- a/src/learnings/learnings.service.ts
+++ b/src/learnings/learnings.service.ts
@@ -100,10 +100,14 @@ export class LearningsService {
         chapter['isCompleted'] = isCompleted;
       });
 
+      // 진도율 추가
+      const { progress } = await this.getProgress(user, type);
+
       return {
         statusCode: 200,
         message: 'Chapters successfully retrieved',
         chapters: learning.chapters,
+        progress,
       };
     } catch (e) {
       throw e;


### PR DESCRIPTION
## Description
챕터에 순서가 필요함에 따라 추가 작업 필요

## Changes
- chapter entity에 order column 추가
- 목차 조회 api response(데이터의 변화는 없지만 순서가 항상 챕터 순서와 동일하도록 수정됨)

### Example
> 이제 아래와 같이 챕터 순서대로 반환됩니다.
```json
{
    "statusCode": 200,
    "message": "Chapters successfully retrieved",
    "chapters": [
        {
            "id": "4d34615a-50be-4dac-9a76-1558d749bde8",
            "title": "챕터 1",
            "helpMessage": null,
            "order": 1,
            "isCompleted": false
        },
        {
            "id": "b18b3b5b-4dbc-4a9a-89d6-4e61aa4ceb2c",
            "title": "챕터 2",
            "helpMessage": null,
            "order": 2,
            "isCompleted": false
        }
    ],
    "progress": 33
}
```

Closes #72 