### PR TITLE
Fix/#107 채점 시 완료 챕터 반영 로직 수정

### DIFF
--- a/src/problems/problems.service.ts
+++ b/src/problems/problems.service.ts
@@ -120,15 +120,8 @@ export class ProblemsService {
           userInDb.completedProblems.push(problem);
         }
         const isChapterComplete =
-          userInDb.completedProblems.filter(
-            (p) => p.chapter.id === problem.chapter.id,
-          ).length >= 3;
-        if (
-          isChapterComplete &&
-          userInDb.completedChapters.find(
-            (chapter) => chapter.id === problem.chapter.id,
-          )
-        ) {
+          userInDb.completedProblems.length >= 3 && submitDto.currentTab === 3;
+        if (isChapterComplete) {
           userInDb.completedChapters.push(problem.chapter);
         }
         await this.userRepository.save(userInDb);


### PR DESCRIPTION
## Description
채점 시 완료 챕터 반영 로직 수정
해당 챕터에서 푼 문제가 아닌 챕터에 관계없이 푼 문제가 3문제 이상일 때 해당 챕터가 완료되도록 하고 있었음.
채점 시 user가 푼 문제의 chapter를 불러오지 못하고 있었음

## Changes
- [x] problemsService 수정

## Additional context
문제의 챕터에 해당하는 문제 중 푼 문제가 3문제 이상일 때만 진도율이 반영되도록 수정
user가 푼 문제의 chapter를 불러오도록 relation 수정
Closes #107 